### PR TITLE
Remove compass easing to fix appearance of discontinuity

### DIFF
--- a/plugins/hud/public/js/compass.js
+++ b/plugins/hud/public/js/compass.js
@@ -36,7 +36,6 @@
         this.canvas.width = this.visibleWidth * 2;
         this.canvas.height = divRect.height;
         this.canvas.style.position = 'absolute';
-        this.canvas.style.transition = 'all 0.3s ease-out';
 
         div.style.overflow = 'hidden';
 


### PR DESCRIPTION
This removes the discontinuity/jump as the drone heading moves through 180 degrees.  Fixes issue #23.
