### PR TITLE
Updated ar-drone dependency from 0.2.0 to 0.2.1 to get GPS data.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "artificial horizon"
   ],
   "dependencies": {
-    "ar-drone": "0.2.0",
+    "ar-drone": "0.2.1",
     "express": "3.0.x",
     "ejs": "~0.8.3",
     "socket.io": "~0.9.4",


### PR DESCRIPTION
I'm working on a map plugin that uses GPS data from the AR.Drone Flight Recorder, and the first step is using the recently updated ar-drone lib that can parse GPS data.

![screen shot 2013-10-03 at 12 34 54 pm](https://f.cloud.github.com/assets/52466/1264674/0f04a9a6-2c63-11e3-87a6-1dd8af52009c.png)
