### PR TITLE
Updated to latest version of node-ar-drone

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "artificial horizon"
   ],
   "dependencies": {
-    "ar-drone": "0.2.1",
+    "ar-drone": "0.3.1",
     "express": "3.0.x",
     "ejs": "~0.8.3",
     "socket.io": "~0.9.4",


### PR DESCRIPTION
Updating to this version of ar-drone has two advantages resulting in better performance:

1) TcpVideoStream fix -- video-stream is less likely to break from endless reconnect loop in `node-ar-drone`.
2) Higher UDP Timeout on controls - less dropped controls = more fluid piloting.
